### PR TITLE
Add markdown support

### DIFF
--- a/carnival.cabal
+++ b/carnival.cabal
@@ -80,6 +80,8 @@ library
                  , yesod-auth-oauth2             >= 0.0.4
                  , http-types
                  , wai
+                 , yesod-markdown                >= 0.8.4
+                 , blaze-markup
 
 executable         carnival
     if flag(library-only)

--- a/config/models
+++ b/config/models
@@ -1,6 +1,6 @@
 Comment
     thread Text
-    body Text
+    body Markdown
     deriving Show
 
 User


### PR DESCRIPTION
Closes #17
- The comment body is assumed to be Markdown
- On the way in, it is stripped of carriage returns
- On the way out, a body_html attribute is added to the JSON
- The body attribute is preserved, possibly for populating edit form
  inputs
