### PR TITLE
Fix cabal-constraints reference in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,6 @@ variable and (re-)running `bin/setup`:
 $ RESET=1 ./bin/setup
 ```
 
-This may be made easier in the future by using [cabal-constraints][].
+This may be made easier in the future by using [cabal-constraints][cabal-constraints].
 
-[cabal-constaints]: https://github.com/thoughtbot/carnival/issues/5
+[cabal-constraints]: https://github.com/thoughtbot/carnival/issues/5


### PR DESCRIPTION
This just fixes the link at the bottom of the README for cabal-constraints.
