### PR TITLE
Add custom Session module

### DIFF
--- a/Foundation.hs
+++ b/Foundation.hs
@@ -20,6 +20,7 @@ import Text.Jasmine (minifym)
 import Text.Hamlet (hamletFile)
 import Yesod.Core.Types (Logger)
 import Control.Applicative ((<$>), (<*>), pure)
+import qualified Session as S
 
 -- | The site argument for your application. This can be a good place to
 -- keep settings and values requiring initialization before your application
@@ -54,11 +55,7 @@ type Form x = Html -> MForm (HandlerT App IO) (FormResult x, Widget)
 instance Yesod App where
     approot = ApprootMaster $ appRoot . settings
 
-    -- Store session data on the client in encrypted cookies,
-    -- default session idle timeout is 120 minutes
-    makeSessionBackend _ = fmap Just $ defaultClientSessionBackend
-        (120 * 60) -- 120 minutes
-        "config/client_session_key.aes"
+    makeSessionBackend _ = S.makeSessionBackend "SESSION_SECRET"
 
     defaultLayout widget = do
         -- We break up the default layout into two components:

--- a/Session.hs
+++ b/Session.hs
@@ -1,0 +1,59 @@
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+-- |
+--
+-- This module provides a session backend which behaves like the default session
+-- backend, but does not use the file system for storing the session key.
+--
+-- Rather, if the named environment variable is present, its value will be used
+-- to generate the session key. By setting the same value in multiple processes,
+-- the user will experience a consistent session even in the presence of load
+-- balancing.
+--
+-- Notes:
+--
+-- 1. If a value is not present or is invalid, a random key will be used which
+--    only lives as long as that process.
+--
+-- 2. The value must be exactly 96 bytes. An appropriate string can be generated
+--    on most unix-like commandlines in the following way:
+--
+-- > hexdump -v -n "48" -e '1/1 "%02x"' /dev/urandom
+--
+module Session (makeSessionBackend) where
+
+import Prelude
+
+import System.Environment (lookupEnv)
+import qualified Data.ByteString.Char8 as BS
+
+import Yesod hiding (makeSessionBackend)
+import qualified Web.ClientSession as CS
+
+makeSessionBackend :: String -> IO (Maybe SessionBackend)
+makeSessionBackend name = fmap Just $ do
+    let minutes = (120 * 60) -- 120 minutes
+        timeout = fromIntegral (minutes * 60)
+
+    key <- getKey name
+
+    (getCachedDate, _) <- clientSessionDateCacher timeout
+
+    return SessionBackend
+        { sbLoadSession = loadClientSession key getCachedDate "_SESSION"
+        }
+
+getKey :: String -> IO CS.Key
+getKey name = do
+    mval <- lookupEnv name
+
+    maybe newKey return $ initKey =<< mval
+
+  where
+    newKey :: IO CS.Key
+    newKey = fmap snd $ CS.randomKey
+
+    initKey :: String -> Maybe CS.Key
+    initKey = eitherToMaybe . CS.initKey . BS.pack
+
+    eitherToMaybe :: Either a b -> Maybe b
+    eitherToMaybe = either (const Nothing) Just

--- a/carnival.cabal
+++ b/carnival.cabal
@@ -19,6 +19,7 @@ library
                      Settings
                      Settings.StaticFiles
                      Settings.Development
+                     Session
                      Helper.Auth
                      Helper.Request
                      Helper.Comment
@@ -86,6 +87,7 @@ library
                  , blaze-markup
                  , gravatar
                  , heroku
+                 , clientsession
 
 executable         carnival
     if flag(library-only)


### PR DESCRIPTION
Read the session key from an environment variable if present. This should get
sessions working across dynos since both dynos will be using the same key and
the data itself is stored in the browser cookie.

I did some local testing and it seems to work as intended. Only when I set a
value in the environment variable do my sessions survive a process restart.

There are some general details in the module doc, but to use it on Heroku, I'm
going to do:

```
% heroku config:set SESSION_SECRET \
 "$(hexdump -v -n "48" -e '1/1 "%02x"' /dev/urandom)"
```
