### PR TITLE
Enable proper CORS support, respond to preflight

### DIFF
--- a/Handler/Comments.hs
+++ b/Handler/Comments.hs
@@ -18,6 +18,11 @@ postCommentsR = do
     sendResponseStatus status201 $ object
         ["comment" .= UserComment (Entity cid c) u]
 
+optionsCommentsR :: Handler ()
+optionsCommentsR = do
+    allowCrossOrigin
+    sendResponseStatus status200 ()
+
 getCommentsR :: Handler Value
 getCommentsR = do
     allowCrossOrigin

--- a/config/routes
+++ b/config/routes
@@ -5,7 +5,7 @@
 /favicon.ico FaviconR GET
 /robots.txt RobotsR GET
 
-/comments CommentsR GET POST
+/comments CommentsR GET POST OPTIONS
 /comments/#CommentId CommentR PUT DELETE
 
 /session SessionR GET

--- a/templates/embed/Carnival.coffee
+++ b/templates/embed/Carnival.coffee
@@ -32,6 +32,7 @@ class Carnival
     request = new XMLHttpRequest
     request.withCredentials = true
     request.open('GET', 'http://' + CarnivalOptions.host + url, true)
+    request.setRequestHeader('Content-Type', 'application/json')
     request.onload = () ->
       if request.status >= 200 and request.status < 400
         callback(JSON.parse(request.responseText))
@@ -41,6 +42,7 @@ class Carnival
     request = new XMLHttpRequest()
     request.withCredentials = true
     request.open('POST', 'http://' + CarnivalOptions.host + url, true)
+    request.setRequestHeader('Content-Type', 'application/json')
     request.onload = () ->
       if request.status >= 200 and request.status < 400
         callback(JSON.parse(@responseText))


### PR DESCRIPTION
This addresses issue #43 by properly responding to the OPTIONS request
and returning the correct requested headers as allowed.
