### PR TITLE
Lessen the line-height for comment body

### DIFF
--- a/templates/embed.lucius
+++ b/templates/embed.lucius
@@ -85,6 +85,7 @@ article.commenting {
       p {
         font-family: sans-serif;
         font-size: 10pt;
+        line-height: 1.5;
         padding: 0;
         margin: 0;
       }


### PR DESCRIPTION
Prompted by this [tweet](https://twitter.com/aaronmoodie/status/512241794047021056)—which I agree with—this lessens the line height on the body text of comments.
