### PR TITLE
Add basic, manual migration handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ yesod-devel/
 .cabal-sandbox
 cabal.sandbox.config
 .env
+!migrations/*.sql

--- a/bin/migrate-deploy
+++ b/bin/migrate-deploy
@@ -1,0 +1,44 @@
+#!/bin/sh
+#
+# usage: ./bin/migrate-deploy [APP] [MIGRATION, ...]
+#
+###
+set -e
+
+if [ $# -lt 2 ]; then
+  sed '/^# \(usage:.*\)/!d; s//\1/' "$0" >&2
+  exit 64
+fi
+
+app="$1"; shift
+
+cat <<EOF
+Running a migration deploy to $app. This will:
+
+  - Put the app in maintenance mode
+  - Backup the database
+  - Execute the given migration scripts in order
+  - Deploy
+  - Take the app out of maintenance mode
+
+If something goes wrong, you may have to manually restore the database backup:
+
+  https://devcenter.heroku.com/articles/pgbackups
+
+Waiting 3 seconds, press ^C to cancel...
+
+EOF
+
+sleep 3
+
+heroku maintenance:on --app "$app"
+heroku pgbackups:capture --app "$app" --expire
+
+for migration; do
+  printf "Migrate: %s\n" "$migration"
+  heroku pg:psql --app "$app" < "$migration"
+done
+
+./bin/deploy "$app"
+
+heroku maintenance:off --app "$app"

--- a/migrations/add-article-title.sql
+++ b/migrations/add-article-title.sql
@@ -1,0 +1,3 @@
+ALTER TABLE comment
+  ADD COLUMN article_title varchar
+  NOT NULL DEFAULT '';

--- a/migrations/rename-article-to-article-url.sql
+++ b/migrations/rename-article-to-article-url.sql
@@ -1,0 +1,2 @@
+ALTER TABLE comment
+  RENAME COLUMN article TO article_u_r_l;

--- a/migrations/update-article-title.sql
+++ b/migrations/update-article-title.sql
@@ -1,0 +1,1 @@
+UPDATE comment SET article_title = article_u_r_l;


### PR DESCRIPTION
This adds a script to run "migration deploys". See the banner in-script for how
the process works (or how I think it'll work). It's not completely tested due
to our other deployment errors (slug too big).

I did test the script with the pg:psql and deploy lines commented, and that
worked. I also tested the individual migration scripts locally, and those
worked.

We need this now because, even if we sort out the slug size issue, the app
won't start in its current state without migrating the article -> articleURL
rename manually.
