### PR TITLE
Abort if Halcyon ENV vars are missing

### DIFF
--- a/bin/halcyon-build
+++ b/bin/halcyon-build
@@ -6,6 +6,13 @@ set -e
 [ -d /app/halcyon ] || \
   git clone https://github.com/mietek/halcyon.git /app/halcyon
 
+if [ -z "$HALCYON_AWS_ACCESS_KEY_ID" ] || \
+  [ -z "$HALCYON_AWS_SECRET_ACCESS_KEY" ] || \
+  [ -z "$HALCYON_S3_BUCKET" ]; then
+  echo "Make sure Halcyon environment variables are set." >&2
+  exit 1
+fi
+
 export HALCYON_NO_SELF_UPDATE=1
 export HALCYON_SANDBOX_EXTRA_CONFIGURE_FLAGS='--enable-tests'
 source <(/app/halcyon/halcyon paths)

--- a/bin/setup
+++ b/bin/setup
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -e
+
 get_env() {
   heroku config --app carnival-staging |\
     sed '/^\(HALCYON_\(AWS_\|S3_\).*\): *\(.*\)/!d; s//export \1=\3/g'


### PR DESCRIPTION
* Prevents accidentally rebuilding all dependencies
* Also abort before printing "Setup complete"