### PR TITLE
Use prefix to make ident unique by OAuth2 provider

### DIFF
--- a/Foundation.hs
+++ b/Foundation.hs
@@ -131,7 +131,7 @@ instance YesodAuth App where
     logoutDest _ = SessionR
 
     getAuthId creds = runDB $ do
-        muser <- getBy $ UniqueUser $ credsIdent creds
+        muser <- getBy $ UniqueUser (credsPlugin creds) (credsIdent creds)
 
         let newUser = buildUser creds
 
@@ -148,11 +148,12 @@ instance YesodAuth App where
     authHttpManager = httpManager
 
 buildUser :: Creds m -> Maybe User
-buildUser (Creds _ csId csExtra) =
+buildUser (Creds csPlugin csIdent csExtra) =
     User <$> lookup "first_name" csExtra
          <*> lookup "last_name" csExtra
          <*> lookup "email" csExtra
-         <*> pure csId
+         <*> pure csPlugin
+         <*> pure csIdent
 
 replaceUser :: UserId -> Maybe User -> YesodDB App UserId
 replaceUser uid (Just u) = replace uid u >> return uid

--- a/config/models
+++ b/config/models
@@ -2,8 +2,9 @@ User
     firstName Text
     lastName Text
     email Text
+    plugin Text
     ident Text
-    UniqueUser ident
+    UniqueUser plugin ident
     deriving Eq Show Typeable
 
 Comment

--- a/migrations/add-plugin-to-user-ident.sql
+++ b/migrations/add-plugin-to-user-ident.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "user" ADD COLUMN plugin varchar;
+UPDATE "user" SET plugin = 'learn';
+ALTER TABLE "user" ALTER COLUMN plugin SET NOT NULL;

--- a/tests/TestHelpers/DB.hs
+++ b/tests/TestHelpers/DB.hs
@@ -39,6 +39,7 @@ createUser ident = do
         { userFirstName = "John" <> ident
         , userLastName  = "Smith"
         , userEmail     = "john-" <> ident <> "@gmail.com"
+        , userPlugin    = "dummy"
         , userIdent     = ident
         }
 


### PR DESCRIPTION
We want to replace Upcase with GitHub for authentication. We need a prefix
before identifiers to ensure there are no collisions between Upcase and GitHub
users.