### PR TITLE
Merge first and last names into name

### DIFF
--- a/Foundation.hs
+++ b/Foundation.hs
@@ -12,6 +12,8 @@ import Network.HTTP.Conduit (Manager)
 import qualified Settings
 import Settings.Development (development)
 import qualified Database.Persist
+import Data.Monoid ((<>))
+import Data.Text (Text)
 import Database.Persist.Sql (SqlBackend)
 import Settings.StaticFiles
 import Settings (widgetFile, Extra (..), LearnOAuthKeys (..))
@@ -149,11 +151,16 @@ instance YesodAuth App where
 
 buildUser :: Creds m -> Maybe User
 buildUser (Creds csPlugin csIdent csExtra) =
-    User <$> lookup "first_name" csExtra
-         <*> lookup "last_name" csExtra
+    User <$> buildName csExtra
          <*> lookup "email" csExtra
          <*> pure csPlugin
          <*> pure csIdent
+
+buildName :: [(Text, Text)] -> Maybe Text
+buildName csExtra = do
+    firstName <- lookup "first_name" csExtra
+    lastName <- lookup "last_name" csExtra
+    return $ firstName <> " " <> lastName
 
 replaceUser :: UserId -> Maybe User -> YesodDB App UserId
 replaceUser uid (Just u) = replace uid u >> return uid

--- a/Handler/Feed.hs
+++ b/Handler/Feed.hs
@@ -1,7 +1,6 @@
 module Handler.Feed where
 
 import Import
-import Model.User
 import Model.UserComment
 
 import Prelude (head)

--- a/Model/User.hs
+++ b/Model/User.hs
@@ -1,7 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Model.User
     ( User(..)
-    , userName
     , userGravatar
     , findUsers
     , findUsers'
@@ -16,14 +15,10 @@ import qualified Data.Text as T
 instance ToJSON (Entity User) where
     toJSON (Entity uid u) = object
         [ "id" .= String (toPathPiece uid)
-        , "first_name" .= userFirstName u
-        , "last_name" .= userLastName u
+        , "name" .= userName u
         , "email" .= userEmail u
         , "gravatar_url" .= userGravatar u
         ]
-
-userName :: User -> Text
-userName u = userFirstName u <> " " <> userLastName u
 
 userGravatar :: User -> Text
 userGravatar = T.pack . gravatar def . userEmail

--- a/config/models
+++ b/config/models
@@ -1,6 +1,5 @@
 User
-    firstName Text
-    lastName Text
+    name Text
     email Text
     plugin Text
     ident Text

--- a/migrations/merge-user-first-and-last-name-into-name.sql
+++ b/migrations/merge-user-first-and-last-name-into-name.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "user" ADD COLUMN name varchar;
+UPDATE "user" SET name = first_name || ' ' || last_name;
+ALTER TABLE "user" ALTER COLUMN name SET NOT NULL;
+ALTER TABLE "user" DROP COLUMN first_name;
+ALTER TABLE "user" DROP COLUMN last_name;

--- a/templates/embed/Carnival.coffee
+++ b/templates/embed/Carnival.coffee
@@ -52,7 +52,7 @@ class Carnival
     request.send(JSON.stringify(data))
 
   @userName: ->
-    Carnival.user.first_name + ' ' + Carnival.user.last_name
+    Carnival.user.name
 
   @userGravatarUrl: ->
     Carnival.user.gravatar_url

--- a/templates/session.hamlet
+++ b/templates/session.hamlet
@@ -5,7 +5,7 @@
 
     $maybe Entity _ u <- mu
         <ul>
-            <li><strong>Name</strong>: #{userFirstName u} #{userLastName u}
+            <li><strong>Name</strong>: #{userName u}
             <li><strong>Email</strong>: #{userEmail u}
     $nothing
         <p>Not authenticated

--- a/tests/TestHelpers/DB.hs
+++ b/tests/TestHelpers/DB.hs
@@ -36,8 +36,7 @@ runDB query = do
 createUser :: Text -> Example (Entity User)
 createUser ident = do
     insertEntity User
-        { userFirstName = "John" <> ident
-        , userLastName  = "Smith"
+        { userName      = "John Smith (" <> ident <> ")"
         , userEmail     = "john-" <> ident <> "@gmail.com"
         , userPlugin    = "dummy"
         , userIdent     = ident


### PR DESCRIPTION
GitHub auth (among other providers) only provides a "name" and not distinct
first and last names. We only ever use the full name, so we can safely merge
these into a single name when we authenticate into providers which provide
both.