### PR TITLE
Use upstream Haskell on Heroku buildpack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
 https://github.com/heroku/heroku-buildpack-nodejs.git#v70
-https://github.com/thoughtbot/haskell-on-heroku.git
+https://github.com/mietek/haskell-on-heroku.git#5d072795

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: ./.halcyon/install/bin/carnival $APP_ENV -p $PORT
+web: ./bin/carnival $APP_ENV -p $PORT


### PR DESCRIPTION
Upstream has significant updates and fixes compared to our out of date fork
and no longer requires the PATH workaround motivating our fork in the first
place.

I've pegged it at the current HEAD revision to ensure consistency. According
to the developer, he won't be consistently tagging releases and v1.0.0 is
lacking some critical fixes with regard to slug size.

Notes:

- Once merged, we should delete our fork from GitHub
- Deployment will require a force-push since I've been testing this branch
  directly on staging