### PR TITLE
Ensure pre-build hook succeeds on non-ubuntu platforms

### DIFF
--- a/.halcyon/sandbox-pre-build-hook
+++ b/.halcyon/sandbox-pre-build-hook
@@ -1,2 +1,6 @@
 #!/bin/sh
-sed -i 's|^#!/usr/bin/nodejs|#!/usr/bin/env nodejs|' /app/sandbox/usr/bin/coffee
+coffee=/app/sandbox/usr/bin/coffee
+
+if [ -f "$coffee" ]; then
+  sed -i 's|^#!/usr/bin/nodejs|#!/usr/bin/env nodejs|' "$coffee"
+fi


### PR DESCRIPTION
We only install the coffee-script extra-os-package on certain platforms. On
platforms where we don't, the pre-build script was failing the build because
/app/sandbox/usr/bin/coffee didn't exit.