### PR TITLE
Change thoughtbot references to use https

### DIFF
--- a/Handler/Feed.hs
+++ b/Handler/Feed.hs
@@ -28,7 +28,7 @@ feedFromComments comments = do
         , feedDescription = "Recent comments on Carnival"
         , feedLanguage    = "en-us"
         , feedLinkSelf    = render FeedR
-        , feedLinkHome    = "http://robots.thoughtbot.com"
+        , feedLinkHome    = "https://robots.thoughtbot.com"
         , feedUpdated     = getCommentCreated $ head comments
         , feedEntries     = entries
         }
@@ -41,7 +41,8 @@ feedFromComments comments = do
 commentToRssEntry :: UserComment -> Handler (FeedEntry Text)
 commentToRssEntry (UserComment (Entity _ c) (Entity _ u)) = 
     return FeedEntry
-        { feedEntryLink = "http://robots.thoughtbot.com/" <> commentArticleURL c
+        { feedEntryLink = "https://robots.thoughtbot.com/"
+            <> commentArticleURL c
         , feedEntryUpdated = commentCreated c
         , feedEntryTitle = "New comment from "
             <> userName u

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Carnival
 
-A medium/disqus-like commenting service powering http://robots.thoughtbot.com.
+A medium/disqus-like commenting service powering https://robots.thoughtbot.com.
 
 ## Credits
 
-![thoughtbot](http://thoughtbot.com/logo.png)
+![thoughtbot](https://thoughtbot.com/logo.png)
 
-Carnival is maintained and funded by [thoughtbot, inc](http://thoughtbot.com/community)
+Carnival is maintained and funded by [thoughtbot, inc](https://thoughtbot.com/community)
 
 Thank you to all [the contributors](https://github.com/thoughtbot/carnival/contributors)!
 
@@ -87,7 +87,7 @@ $ ./bin/deploy carnival-production
 
 Read more about deploying Carnival in [Ship You A Haskell][ship-you].
 
-[ship-you]: http://robots.thoughtbot.com/ship-you-a-haskell
+[ship-you]: https://robots.thoughtbot.com/ship-you-a-haskell
 
 ## Migrations
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,9 +12,9 @@ Testing:
   <<: *defaults
 
 Staging:
-  approot: "http://carnival-staging.herokuapp.com"
+  approot: "https://carnival-staging.herokuapp.com"
   <<: *defaults
 
 Production:
-  approot: "http://carnival.thoughtbot.com"
+  approot: "https://carnival.thoughtbot.com"
   <<: *defaults

--- a/templates/embed/Carnival.coffee
+++ b/templates/embed/Carnival.coffee
@@ -34,7 +34,7 @@ class Carnival
   @get: (url, callback) ->
     request = new XMLHttpRequest
     request.withCredentials = true
-    request.open('GET', 'http://' + CarnivalOptions.host + url, true)
+    request.open('GET', 'https://' + CarnivalOptions.host + url, true)
     request.setRequestHeader('Content-Type', 'application/json')
     request.onload = () ->
       if request.status >= 200 and request.status < 400
@@ -44,7 +44,7 @@ class Carnival
   @post: (url, data, callback) ->
     request = new XMLHttpRequest()
     request.withCredentials = true
-    request.open('POST', 'http://' + CarnivalOptions.host + url, true)
+    request.open('POST', 'https://' + CarnivalOptions.host + url, true)
     request.setRequestHeader('Content-Type', 'application/json')
     request.onload = () ->
       if request.status >= 200 and request.status < 400
@@ -67,13 +67,13 @@ class Carnival
   @getUser: ->
     request = new XMLHttpRequest
     request.withCredentials = true
-    request.open('GET', 'http://' + CarnivalOptions.host + '/user', false)
+    request.open('GET', 'https://' + CarnivalOptions.host + '/user', false)
     request.send()
     if request.status is 200
       @user = JSON.parse(request.responseText).user
 
   @hasLoggedIn: (event) =>
-    if event.origin != 'http://' + CarnivalOptions.host
+    if event.origin != 'https://' + CarnivalOptions.host
       return
     @loginWindow.close()
     @getUser()
@@ -85,7 +85,7 @@ class Carnival
     left = (screen.width/2)-(width/2)
     top = (screen.height/2)-(height/2)
     @loginWindow = window.open(
-      'http://' + CarnivalOptions.host + '/auth/page/github/forward',
+      'https://' + CarnivalOptions.host + '/auth/page/github/forward',
       'carnivalLogin',
       'height='+height+',width='+width+',top='+top+',left='+left+',menubar=no'
     )

--- a/templates/mail/new_comment.text
+++ b/templates/mail/new_comment.text
@@ -1,5 +1,5 @@
 #{comment}
 
 -- 
-View this comment: http://robots.thoughtbot.com/#{articleUrl}
+View this comment: https://robots.thoughtbot.com/#{articleUrl}
 Unsubscribe: @{unsubscribeRoute}


### PR DESCRIPTION
* We now support https for the blog
* We have an SSL endpoint for this app on Heroku
* We have a wildcard cert for thoughtbot.com subdomains
* We need to serve https references to avoid unsafe warnings