### PR TITLE
Configure gravatar to use https

### DIFF
--- a/.halcyon/constraints
+++ b/.halcyon/constraints
@@ -62,7 +62,7 @@ fast-logger-2.2.3
 filepath-1.3.0.2
 file-embed-0.0.7
 ghc-prim-0.3.1.0
-gravatar-0.6
+gravatar-0.7
 hashable-1.2.3.1
 heroku-0.1.2.1
 heroku-persistent-0.1.0


### PR DESCRIPTION
* We're serving the blog over https
* We get mixed content warnings for http images