### PR TITLE
Use interpolated, type-safe URLs in coffee-script

### DIFF
--- a/Handler/Embed.hs
+++ b/Handler/Embed.hs
@@ -3,8 +3,14 @@ module Handler.Embed where
 import Import
 import Helper.Request
 
+import Text.Julius (rawJS)
+import Yesod.Auth (Route(PluginR))
+import Yesod.Default.Config (appRoot)
+
 getEmbedR :: Handler Html
 getEmbedR = do
+    root <- fmap (rawJS . appRoot . settings) getYesod
+
     allowCrossOrigin
     embedLayout $ do
         toWidget $(luciusFile "embed")

--- a/templates/embed/Article.coffee
+++ b/templates/embed/Article.coffee
@@ -28,7 +28,7 @@ class Article
         Carnival.removeClass(@element, 'commenting')
 
   fetchComments: ->
-    Carnival.get('/comments?article=' + @id, (data) =>
+    Carnival.get('@{CommentsR}?article=' + @id, (data) =>
       @commentData = data.comments
       @createBlocks()
       @insertBlocksIntoDom()

--- a/templates/embed/Carnival.coffee
+++ b/templates/embed/Carnival.coffee
@@ -34,7 +34,7 @@ class Carnival
   @get: (url, callback) ->
     request = new XMLHttpRequest
     request.withCredentials = true
-    request.open('GET', 'https://' + CarnivalOptions.host + url, true)
+    request.open('GET', url, true)
     request.setRequestHeader('Content-Type', 'application/json')
     request.onload = () ->
       if request.status >= 200 and request.status < 400
@@ -44,7 +44,7 @@ class Carnival
   @post: (url, data, callback) ->
     request = new XMLHttpRequest()
     request.withCredentials = true
-    request.open('POST', 'https://' + CarnivalOptions.host + url, true)
+    request.open('POST', url, true)
     request.setRequestHeader('Content-Type', 'application/json')
     request.onload = () ->
       if request.status >= 200 and request.status < 400
@@ -67,13 +67,13 @@ class Carnival
   @getUser: ->
     request = new XMLHttpRequest
     request.withCredentials = true
-    request.open('GET', 'https://' + CarnivalOptions.host + '/user', false)
+    request.open('GET', '@{UserR}', false)
     request.send()
     if request.status is 200
       @user = JSON.parse(request.responseText).user
 
   @hasLoggedIn: (event) =>
-    if event.origin != 'https://' + CarnivalOptions.host
+    if event.origin != '%{root}'
       return
     @loginWindow.close()
     @getUser()
@@ -85,7 +85,7 @@ class Carnival
     left = (screen.width/2)-(width/2)
     top = (screen.height/2)-(height/2)
     @loginWindow = window.open(
-      'https://' + CarnivalOptions.host + '/auth/page/github/forward',
+      '@{AuthR $ PluginR "github" ["forward"]}',
       'carnivalLogin',
       'height='+height+',width='+width+',top='+top+',left='+left+',menubar=no'
     )

--- a/templates/embed/Thread.coffee
+++ b/templates/embed/Thread.coffee
@@ -41,7 +41,7 @@ class Thread
 
   add: (body) ->
     Carnival.post(
-      '/comments',
+      '@{CommentsR}',
       @commentHash(body),
       (response) =>
         comment = new Comment(response.comment)

--- a/test/Handler/EmbedSpec.hs
+++ b/test/Handler/EmbedSpec.hs
@@ -1,0 +1,14 @@
+module Handler.EmbedSpec where
+
+import TestHelper
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = withApp $
+    describe "GET EmbedR" $
+        it "renders successfully" $ do
+            get EmbedR
+
+            statusIs 200


### PR DESCRIPTION
- Removes CarnivalOptions.host
- Removes client-side URL building
- Ensures that URL changes will not compile without updating the javascript;
  when we change endpoints for #105, we can't forget coffee-script changes