### PR TITLE
Begin allowing Site-specific data

### DIFF
--- a/Handler/Comments.hs
+++ b/Handler/Comments.hs
@@ -38,8 +38,8 @@ instance FromJSON CommentRequest where
 
     parseJSON _ = mzero
 
-postCommentsR :: Handler Value
-postCommentsR = do
+postCommentsR :: SiteId -> Handler Value
+postCommentsR _ = do
     allowCrossOrigin
 
     u <- requireAuth_
@@ -57,8 +57,8 @@ postCommentsR = do
         sendNotification notification
         sendResponseStatus status201 $ object ["comment" .= userComment]
 
-putCommentR :: CommentId -> Handler Value
-putCommentR commentId = do
+putCommentR :: SiteId -> CommentId -> Handler Value
+putCommentR _ commentId = do
     allowCrossOrigin
 
     u <- requireAuth_
@@ -74,8 +74,8 @@ putCommentR commentId = do
         sendResponseStatus status200 $ object
             ["comment" .= UserComment (Entity commentId v) u]
 
-deleteCommentR :: CommentId -> Handler ()
-deleteCommentR commentId = do
+deleteCommentR :: SiteId -> CommentId -> Handler ()
+deleteCommentR _ commentId = do
     allowCrossOrigin
 
     u <- requireAuth_
@@ -87,8 +87,8 @@ deleteCommentR commentId = do
 
     sendResponseStatus status200 ("DELETED" :: Text)
 
-getCommentsR :: Handler Value
-getCommentsR = do
+getCommentsR :: SiteId -> Handler Value
+getCommentsR _ = do
     allowCrossOrigin
 
     marticle <- lookupGetParam "article"
@@ -96,8 +96,8 @@ getCommentsR = do
 
     return $ object ["comments" .= comments]
 
-optionsCommentsR :: Handler ()
-optionsCommentsR = do
+optionsCommentsR :: SiteId -> Handler ()
+optionsCommentsR _ = do
     allowCrossOrigin
 
     sendResponseStatus status200 ()

--- a/Handler/Embed.hs
+++ b/Handler/Embed.hs
@@ -7,8 +7,8 @@ import Text.Julius (rawJS)
 import Yesod.Auth (Route(PluginR))
 import Yesod.Default.Config (appRoot)
 
-getEmbedR :: Handler Html
-getEmbedR = do
+getEmbedR :: SiteId -> Handler Html
+getEmbedR siteId = do
     root <- fmap (rawJS . appRoot . settings) getYesod
 
     allowCrossOrigin

--- a/README.md
+++ b/README.md
@@ -71,6 +71,30 @@ Open up a REPL:
 $ cabal exec -- ghci Model.hs
 ```
 
+## Maitre-d
+
+To use Carnival from a local instance of [maitre-d][]:
+
+- Find the id of your development Site (it'll probably be `1`):
+
+```
+% echo "select id from site where base_url LIKE '%localhost%';" | psql carnival
+ id
+----
+  1
+(1 row)
+
+```
+
+- Set `CARNIVAL_HOST` for maitre-d:
+
+```
+CARNIVAL_ENABLED=true
+CARNIVAL_HOST='localhost:3000/sites/1'
+```
+
+[maitre-d]: https://github.com/thoughtbot/maitre-d
+
 ## Deployment
 
 Staging is the default deploy target:

--- a/bin/setup-db
+++ b/bin/setup-db
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+_psql() { PGPASSWORD="$user" psql --username "$user" "$@"; }
+
+missing_sites() {
+  echo 'select count(*) from site;' | _psql -t --dbname "$app" | grep -Fq 0
+}
+
 app='carnival'
 user="$app"
 
@@ -24,5 +30,9 @@ psql template1 >/dev/null <<SQL
 SQL
 
 # Test connections
-PGPASSWORD="$user" psql --username "$user" --dbname "$app" </dev/null
-PGPASSWORD="$user" psql --username "$user" --dbname "${app}_test" </dev/null
+_psql --dbname "$app" </dev/null
+_psql --dbname "${app}_test" </dev/null
+
+# Create site records if needed
+_psql --dbname "$app" < migrations/create-site.psql
+missing_sites && _psql --dbname "$app" < migrations/insert-thoughtbot-sites.psql

--- a/config/models
+++ b/config/models
@@ -1,3 +1,11 @@
+Site
+    name Text
+    baseUrl Text
+    rssAuthor Text
+    rssTitle Text
+    rssDescription Html
+    rssLanguage Text
+
 User
     name Text
     email Text

--- a/config/routes
+++ b/config/routes
@@ -1,14 +1,14 @@
 /static StaticR Static getStatic
 /auth   AuthR   Auth   getAuth
-/embed EmbedR GET
 
 /favicon.ico FaviconR GET
 /robots.txt RobotsR GET
 
-/comments CommentsR GET POST OPTIONS
-/comments/#CommentId CommentR PUT DELETE
-
+/sites/#SiteId/embed EmbedR GET
 /sites/#SiteId/feed FeedR GET
+
+/sites/#SiteId/comments CommentsR GET POST OPTIONS
+/sites/#SiteId/comments/#CommentId CommentR PUT DELETE
 
 /session SessionR GET
 /user UserR GET

--- a/config/routes
+++ b/config/routes
@@ -8,7 +8,7 @@
 /comments CommentsR GET POST OPTIONS
 /comments/#CommentId CommentR PUT DELETE
 
-/feed FeedR GET
+/sites/#SiteId/feed FeedR GET
 
 /session SessionR GET
 /user UserR GET

--- a/migrations/create-site.psql
+++ b/migrations/create-site.psql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS site (
+  id                    SERIAL PRIMARY KEY UNIQUE,
+  name                  VARCHAR NOT NULL,
+  base_url              VARCHAR NOT NULL,
+  rss_author            VARCHAR NOT NULL,
+  rss_title             VARCHAR NOT NULL,
+  rss_description       VARCHAR NOT NULL,
+  rss_language          VARCHAR NOT NULL
+);

--- a/migrations/insert-thoughtbot-sites.psql
+++ b/migrations/insert-thoughtbot-sites.psql
@@ -1,0 +1,24 @@
+INSERT INTO site
+  (name, base_url, rss_author, rss_title, rss_description, rss_language) VALUES
+  (
+    'robots-development',
+    'http://localhost:4000',
+    'thoughtbot',
+    'Carnival Comments',
+    'Recent comments on Carnival',
+    'en-us'
+  ), (
+    'robots-staging',
+    'https://robots-staging.thoughtbot.com',
+    'thoughtbot',
+    'Carnival Comments',
+    'Recent comments on Carnival',
+    'en-us'
+  ), (
+    'robots-production',
+    'https://robots.thoughtbot.com',
+    'thoughtbot',
+    'Carnival Comments',
+    'Recent comments on Carnival',
+    'en-us'
+  );

--- a/templates/embed/Article.coffee
+++ b/templates/embed/Article.coffee
@@ -28,7 +28,7 @@ class Article
         Carnival.removeClass(@element, 'commenting')
 
   fetchComments: ->
-    Carnival.get('@{CommentsR}?article=' + @id, (data) =>
+    Carnival.get('@{CommentsR siteId}?article=' + @id, (data) =>
       @commentData = data.comments
       @createBlocks()
       @insertBlocksIntoDom()

--- a/templates/embed/Thread.coffee
+++ b/templates/embed/Thread.coffee
@@ -41,7 +41,7 @@ class Thread
 
   add: (body) ->
     Carnival.post(
-      '@{CommentsR}',
+      '@{CommentsR siteId}',
       @commentHash(body),
       (response) =>
         comment = new Comment(response.comment)

--- a/test/Handler/EmbedSpec.hs
+++ b/test/Handler/EmbedSpec.hs
@@ -9,6 +9,8 @@ spec :: Spec
 spec = withApp $
     describe "GET EmbedR" $
         it "renders successfully" $ do
-            get EmbedR
+            Entity siteId _ <- createSite
+
+            get $ EmbedR siteId
 
             statusIs 200

--- a/test/TestHelpers/DB.hs
+++ b/test/TestHelpers/DB.hs
@@ -3,6 +3,7 @@
 module TestHelpers.DB
     ( runDB
     , runDBWithApp
+    , createSite
     , createUser
     , createComment
     , createSubscription
@@ -36,6 +37,17 @@ runDB query = do
 
 runDBWithApp :: App -> SqlPersistM a -> IO a
 runDBWithApp app query = runSqlPersistMPool query (connPool app)
+
+createSite :: Example (Entity Site)
+createSite =
+    insertEntity Site
+        { siteName = "site-name"
+        , siteBaseUrl = "http://localhost:4000"
+        , siteRssAuthor = "Rss Author"
+        , siteRssTitle = "Rss Feed"
+        , siteRssDescription = "Rss Feed"
+        , siteRssLanguage = "en-us"
+        }
 
 createUser :: Text -> Example (Entity User)
 createUser ident =


### PR DESCRIPTION
Changes:

- Create Site model
- Migrations to create dev/staging/production blog records
- Add `/sites/#SiteId` prefix to most routes
- Render FeedR and EmbedR for a specific Site
- EmbedR uses its SiteId in comments API calls

Deployment:

- Requires migrate-deploy (create-site, insert-thoughtbot-sites)
- Comments will temporarily not work, only until I modify CARNIVAL_HOST on
  staging/production to include the `/sites/#SiteId` prefix
- Zapier hook will need to be changed to include `/sites/#SiteId` prefix