### PR TITLE
Add commentSite attribute to Comment

### DIFF
--- a/config/models
+++ b/config/models
@@ -16,6 +16,7 @@ User
 
 Comment
     user UserId
+    site SiteId default=1
     articleURL Text
     articleTitle Text default=''
     articleAuthor Text default=''

--- a/test/Handler/CommentsSpec.hs
+++ b/test/Handler/CommentsSpec.hs
@@ -11,11 +11,12 @@ spec :: Spec
 spec = withApp $ do
     describe "GET CommentsR" $ do
         it "returns a list of comments by article" $ do
-            u <- createUser "1"
-            c1 <- createComment (entityKey u) "1" "1" "1"
-            c2 <- createComment (entityKey u) "1" "2" "2"
-            c3 <- createComment (entityKey u) "2" "1" "3"
             Entity siteId _ <- createSite
+
+            u <- createUser "1"
+            c1 <- createComment (entityKey u) siteId "1" "1" "1"
+            c2 <- createComment (entityKey u) siteId "1" "2" "2"
+            c3 <- createComment (entityKey u) siteId "2" "1" "3"
 
             get $ CommentsR siteId
 
@@ -87,9 +88,9 @@ spec = withApp $ do
         it "only allows manipulating your own comments" $ do
             u1 <- createUser "1"
             u2 <- createUser "2"
-            Entity cid1 _ <- createComment (entityKey u1) "1" "1" "1"
-            Entity cid2 _ <- createComment (entityKey u2) "1" "1" "2"
             Entity siteId _ <- createSite
+            Entity cid1 _ <- createComment (entityKey u1) siteId "1" "1" "1"
+            Entity cid2 _ <- createComment (entityKey u2) siteId "1" "1" "2"
 
             authenticateAs u2
 
@@ -115,9 +116,9 @@ spec = withApp $ do
         it "only allows deleting your own comments" $ do
             u1 <- createUser "1"
             u2 <- createUser "2"
-            Entity cid1 _ <- createComment (entityKey u1) "1" "1" "1"
-            Entity cid2 _ <- createComment (entityKey u2) "1" "1" "2"
             Entity siteId _ <- createSite
+            Entity cid1 _ <- createComment (entityKey u1) siteId "1" "1" "1"
+            Entity cid2 _ <- createComment (entityKey u2) siteId "1" "1" "2"
 
             authenticateAs u2
 

--- a/test/NotificationSpec.hs
+++ b/test/NotificationSpec.hs
@@ -13,13 +13,14 @@ spec = withApp $ do
         describe "NewComment" $ do
             describe "notificationRecipients" $ do
                 it "contains any users subscribed to the notification" $ do
+                    Entity siteId _ <- createSite
                     users1 <- mapM createUser ["1", "2", "3"]
                     users2 <- mapM createUser ["4", "5", "6"]
                     users3 <- mapM createUser ["7", "8", "9"]
-                    mapM_ (subscribeUser "1" "1") users1
-                    mapM_ (subscribeUser "1" "2") users2
-                    mapM_ (subscribeUser "2" "1") users3
-                    n <- createNotification "1" "2" =<< createUser "10"
+                    mapM_ (subscribeUser siteId "1" "1") users1
+                    mapM_ (subscribeUser siteId "1" "2") users2
+                    mapM_ (subscribeUser siteId "2" "1") users3
+                    n <- createNotification siteId "1" "2" =<< createUser "10"
 
                     rs <- runDB $ notificationRecipients n
 
@@ -28,8 +29,9 @@ spec = withApp $ do
                         (map (userEmail . recipientUser) rs)
 
                 it "provides a valid token for unsubscribing" $ do
-                    subscribeUser "1" "1" =<< createUser "1"
-                    n <- createNotification "1" "1" =<< createUser "2"
+                    Entity siteId _ <- createSite
+                    subscribeUser siteId "1" "1" =<< createUser "1"
+                    n <- createNotification siteId "1" "1" =<< createUser "2"
                     (r:_) <- runDB $ notificationRecipients n
 
                     get $ UnsubscribeR $ recipientToken r

--- a/test/TestHelpers/DB.hs
+++ b/test/TestHelpers/DB.hs
@@ -58,12 +58,13 @@ createUser ident =
         , userIdent     = ident
         }
 
-createComment :: UserId -> Text -> Text -> TL.Text -> Example (Entity Comment)
-createComment uid article thread body = do
+createComment :: UserId -> SiteId -> Text -> Text -> TL.Text -> Example (Entity Comment)
+createComment uid siteId article thread body = do
     now <- liftIO getCurrentTime
 
     insertEntity Comment
         { commentUser = uid
+        , commentSite = siteId
         , commentThread = thread
         , commentArticleTitle = "title"
         , commentArticleURL = article
@@ -75,15 +76,15 @@ createComment uid article thread body = do
 createSubscription :: Text -> Entity User -> Example ()
 createSubscription name (Entity uid _) = runDB $ subscribe name uid
 
-createNotification :: Text -> Text -> Entity User -> Example Notification
-createNotification article thread u = do
-    c <- createComment (entityKey u) article thread ""
+createNotification :: SiteId -> Text -> Text -> Entity User -> Example Notification
+createNotification siteId article thread u = do
+    c <- createComment (entityKey u) siteId article thread ""
 
     return $ NewComment $ UserComment c u
 
-subscribeUser :: Text -> Text -> Entity User -> Example ()
-subscribeUser article thread eu = do
-    notification <- createNotification article thread eu
+subscribeUser :: SiteId -> Text -> Text -> Entity User -> Example ()
+subscribeUser siteId article thread eu = do
+    notification <- createNotification siteId article thread eu
 
     createSubscription (notificationName notification) eu
 


### PR DESCRIPTION
This is phase 1 of 2. Here, all existing comments are given an incorrect 
SiteId of 1. This is OK because we aren't using it for anything yet. After
deployment, I will manually update all existing comments to have the correct
SiteId. I can then follow up with Phase 2: actually rely on commentSite.