### PR TITLE
Make all actions site-specific

### DIFF
--- a/Handler/Comments.hs
+++ b/Handler/Comments.hs
@@ -92,11 +92,11 @@ deleteCommentR _ commentId = do
     sendResponseStatus status200 ("DELETED" :: Text)
 
 getCommentsR :: SiteId -> Handler Value
-getCommentsR _ = do
+getCommentsR siteId = do
     allowCrossOrigin
 
     marticle <- lookupGetParam "article"
-    comments <- runDB $ findUserComments marticle
+    comments <- runDB $ findUserComments siteId marticle
 
     return $ object ["comments" .= comments]
 

--- a/Handler/Feed.hs
+++ b/Handler/Feed.hs
@@ -36,17 +36,19 @@ feedFromComments (Entity siteId site) comments = do
 
     where
         getCommentCreated :: UserComment -> UTCTime
-        getCommentCreated (UserComment (Entity _ c) _) =
-            commentCreated c
+        getCommentCreated = commentCreated . entityVal . userCommentComment
 
 commentToRssEntry :: Site -> UserComment -> Handler (FeedEntry Text)
-commentToRssEntry site (UserComment (Entity _ c) (Entity _ u)) =
-    return FeedEntry
-        { feedEntryLink = siteBaseUrl site <> commentArticleURL c
-        , feedEntryUpdated = commentCreated c
-        , feedEntryTitle = "New comment from "
-            <> userName u
-            <> " on " <> commentArticleTitle c
-            <> " by " <> commentArticleAuthor c
-        , feedEntryContent = toMarkup $ commentBody c
-        }
+commentToRssEntry site userComment = return FeedEntry
+    { feedEntryLink = siteBaseUrl site <> commentArticleURL comment
+    , feedEntryUpdated = commentCreated comment
+    , feedEntryTitle = "New comment from "
+        <> userName user
+        <> " on " <> commentArticleTitle comment
+        <> " by " <> commentArticleAuthor comment
+    , feedEntryContent = toMarkup $ commentBody comment
+    }
+
+  where
+    comment = entityVal $ userCommentComment userComment
+    user = entityVal $ userCommentUser userComment

--- a/Model/UserComment.hs
+++ b/Model/UserComment.hs
@@ -6,7 +6,7 @@ import Model.User
 
 import Control.Monad (forM)
 import Data.List (find)
-import Data.Maybe (catMaybes, maybeToList)
+import Data.Maybe (catMaybes)
 
 data UserComment = UserComment (Entity Comment) (Entity User)
 
@@ -23,9 +23,12 @@ instance ToJSON UserComment where
         , "body_html" .= String (renderMarkdown c)
         ]
 
-findUserComments :: Maybe Text -> DB [UserComment]
-findUserComments marticle = do
-    let filters = maybeToList $ fmap (CommentArticleURL ==.) marticle
+findUserComments :: SiteId -> Maybe Text -> DB [UserComment]
+findUserComments siteId marticle = do
+    let filters = catMaybes
+            [ Just $ CommentSite ==. siteId
+            , fmap (CommentArticleURL ==.) marticle
+            ]
 
     selectWithUsers filters []
 

--- a/Notification.hs
+++ b/Notification.hs
@@ -17,7 +17,6 @@ import SendMail
 import Control.Monad ((<=<), forM)
 import Data.List (find)
 import Data.Maybe (catMaybes)
-import Data.Text.Lazy (fromStrict)
 import Data.Text.Lazy.Builder (toLazyText)
 import Network.Mail.Mime (simpleMail')
 
@@ -32,6 +31,10 @@ data Recipient = Recipient
 notificationUser :: Notification -> User
 notificationUser (NewComment userComment) =
     entityVal $ userCommentUser userComment
+
+notificationSite :: Notification -> Site
+notificationSite (NewComment userComment) =
+    entityVal $ userCommentSite userComment
 
 notificationComment :: Notification -> Comment
 notificationComment (NewComment userComment) =
@@ -75,7 +78,8 @@ notificationToMail n r = do
     let c = notificationComment n
         subject = "New comment on " <> commentArticleTitle c
         comment = unMarkdown $ commentBody c
-        articleUrl = fromStrict $ commentArticleURL c
+        baseUrl = siteBaseUrl $ notificationSite n
+        articleUrl = commentArticleURL c
         unsubscribeRoute = UnsubscribeR $ recipientToken r
 
     body <- toLazyText <$> withUrlRenderer $(textFile "mail/new_comment")

--- a/Notification.hs
+++ b/Notification.hs
@@ -30,10 +30,12 @@ data Recipient = Recipient
     deriving (Eq, Show)
 
 notificationUser :: Notification -> User
-notificationUser (NewComment (UserComment _ (Entity _ u))) = u
+notificationUser (NewComment userComment) =
+    entityVal $ userCommentUser userComment
 
 notificationComment :: Notification -> Comment
-notificationComment (NewComment (UserComment (Entity _ c) _)) = c
+notificationComment (NewComment userComment) =
+    entityVal $ userCommentComment userComment
 
 recipientAddress :: Recipient -> Address
 recipientAddress r =

--- a/templates/mail/new_comment.text
+++ b/templates/mail/new_comment.text
@@ -1,5 +1,5 @@
 #{comment}
 
 -- 
-View this comment: https://robots.thoughtbot.com/#{articleUrl}
+View this comment: #{baseUrl}/#{articleUrl}
 Unsubscribe: @{unsubscribeRoute}

--- a/test/Handler/CommentsSpec.hs
+++ b/test/Handler/CommentsSpec.hs
@@ -20,11 +20,11 @@ spec = withApp $ do
 
             get $ CommentsR siteId
 
-            valueEquals =<< commentsResponse u [c1, c2, c3]
+            valueEquals =<< commentsResponse siteId u [c1, c2, c3]
 
             getWithParams (CommentsR siteId) [("article", "1")]
 
-            valueEquals =<< commentsResponse u [c1, c2]
+            valueEquals =<< commentsResponse siteId u [c1, c2]
 
         it "returns comments for the correct site" $ do
             Entity sid1 _ <- createSite
@@ -38,11 +38,11 @@ spec = withApp $ do
 
             get $ CommentsR sid1
 
-            valueEquals =<< commentsResponse u [c1, c3]
+            valueEquals =<< commentsResponse sid1 u [c1, c3]
 
             get $ CommentsR sid2
 
-            valueEquals =<< commentsResponse u [c2, c4]
+            valueEquals =<< commentsResponse sid2 u [c2, c4]
 
     describe "POST CommentsR" $ do
         it "does not allow unauthenticated commenting" $ do
@@ -69,7 +69,7 @@ spec = withApp $ do
             statusIs 201
 
             (e@(Entity _ c):_) <- runDB $ selectList [] []
-            userComment <- runDB $ buildUserComment e u
+            userComment <- runDB $ buildUserComment siteId e u
 
             valueEquals $ object ["comment" .= userComment]
 

--- a/test/Handler/CommentsSpec.hs
+++ b/test/Handler/CommentsSpec.hs
@@ -41,7 +41,6 @@ spec = withApp $ do
 
             statusIs 401
 
-
         it "allows commenting by authenticated users" $ do
             u <- createUser "1"
             Entity siteId _ <- createSite

--- a/test/Handler/CommentsSpec.hs
+++ b/test/Handler/CommentsSpec.hs
@@ -33,6 +33,30 @@ spec = withApp $ do
                                , UserComment c2 u
                                ]]
 
+        it "returns comments for the correct site" $ do
+            Entity sid1 _ <- createSite
+            Entity sid2 _ <- createSite
+
+            u <- createUser "1"
+            c1 <- createComment (entityKey u) sid1 "1" "1" "1"
+            c2 <- createComment (entityKey u) sid2 "1" "1" "1"
+            c3 <- createComment (entityKey u) sid1 "1" "1" "2"
+            c4 <- createComment (entityKey u) sid2 "1" "1" "2"
+
+            get $ CommentsR sid1
+
+            valueEquals $ object
+                ["comments" .= [ UserComment c1 u
+                               , UserComment c3 u
+                               ]]
+
+            get $ CommentsR sid2
+
+            valueEquals $ object
+                ["comments" .= [ UserComment c2 u
+                               , UserComment c4 u
+                               ]]
+
     describe "POST CommentsR" $ do
         it "does not allow unauthenticated commenting" $ do
             Entity siteId _ <- createSite

--- a/test/TestHelper.hs
+++ b/test/TestHelper.hs
@@ -42,6 +42,7 @@ import Yesod.Test as X
 -- Test helpers
 import TestHelpers.DB as X
 import TestHelpers.Request as X
+import TestHelpers.Response as X
 import TestHelpers.Assertions as X
 import TestHelpers.Auth as X
 

--- a/test/TestHelpers/DB.hs
+++ b/test/TestHelpers/DB.hs
@@ -80,7 +80,7 @@ createNotification :: SiteId -> Text -> Text -> Entity User -> Example Notificat
 createNotification siteId article thread u = do
     c <- createComment (entityKey u) siteId article thread ""
 
-    return $ NewComment $ UserComment c u
+    fmap NewComment $ runDB $ buildUserComment c u
 
 subscribeUser :: SiteId -> Text -> Text -> Entity User -> Example ()
 subscribeUser siteId article thread eu = do

--- a/test/TestHelpers/DB.hs
+++ b/test/TestHelpers/DB.hs
@@ -80,7 +80,7 @@ createNotification :: SiteId -> Text -> Text -> Entity User -> Example Notificat
 createNotification siteId article thread u = do
     c <- createComment (entityKey u) siteId article thread ""
 
-    fmap NewComment $ runDB $ buildUserComment c u
+    fmap NewComment $ runDB $ buildUserComment siteId c u
 
 subscribeUser :: SiteId -> Text -> Text -> Entity User -> Example ()
 subscribeUser siteId article thread eu = do

--- a/test/TestHelpers/Response.hs
+++ b/test/TestHelpers/Response.hs
@@ -14,9 +14,12 @@ import Data.Aeson (Value, object, (.=))
 import Database.Persist
 import Yesod.Test
 
-commentsResponse :: Entity User -> [Entity Comment] -> YesodExample App Value
-commentsResponse user comments = runDB $ do
+commentsResponse :: SiteId
+                 -> Entity User
+                 -> [Entity Comment]
+                 -> YesodExample App Value
+commentsResponse siteId user comments = runDB $ do
     userComments <- forM comments $ \comment ->
-        buildUserComment comment user
+        buildUserComment siteId comment user
 
     return $ object ["comments" .= userComments]

--- a/test/TestHelpers/Response.hs
+++ b/test/TestHelpers/Response.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE OverloadedStrings #-}
+module TestHelpers.Response
+    ( commentsResponse
+    ) where
+
+import Model
+import Model.UserComment
+import Foundation
+
+import TestHelpers.DB
+
+import Control.Monad (forM)
+import Data.Aeson (Value, object, (.=))
+import Database.Persist
+import Yesod.Test
+
+commentsResponse :: Entity User -> [Entity Comment] -> YesodExample App Value
+commentsResponse user comments = runDB $ do
+    userComments <- forM comments $ \comment ->
+        buildUserComment comment user
+
+    return $ object ["comments" .= userComments]


### PR DESCRIPTION
- Fetch comments scoped to the given site
- Use the comment's site to render Email link

Note: aace81a is a big refactor commit to remove all direct uses of the
UserComment constructor, replaced by a smart builder and record accessors. With
that done, eac57a3 (adding a Site field to it) was a much smaller change. I
suggest reviewing those two separately and in isolation.

With this, Carnival fully supports multiple sites run from the same installed
instance.