### PR TITLE
Add InitR, a single JS script to load Carnival

### DIFF
--- a/Application.hs
+++ b/Application.hs
@@ -34,6 +34,7 @@ import qualified Data.Text as T
 -- Don't forget to add new modules to your cabal file!
 import Handler.Comments
 import Handler.Session
+import Handler.Init
 import Handler.Embed
 import Handler.User
 import Handler.Feed

--- a/Handler/Init.hs
+++ b/Handler/Init.hs
@@ -1,0 +1,7 @@
+module Handler.Init where
+
+import Import
+import Text.Julius
+
+getInitR :: SiteId -> Handler Javascript
+getInitR siteId = withUrlRenderer $(coffeeFile "init")

--- a/carnival.cabal
+++ b/carnival.cabal
@@ -32,6 +32,7 @@ library
                      Helper.Validation
                      Handler.Session
                      Handler.Comments
+                     Handler.Init
                      Handler.Embed
                      Handler.User
                      Handler.Feed

--- a/config/routes
+++ b/config/routes
@@ -4,6 +4,7 @@
 /favicon.ico FaviconR GET
 /robots.txt RobotsR GET
 
+/sites/#SiteId/init.js InitR GET
 /sites/#SiteId/embed EmbedR GET
 /sites/#SiteId/feed FeedR GET
 

--- a/templates/embed/Carnival.coffee
+++ b/templates/embed/Carnival.coffee
@@ -1,21 +1,9 @@
 class Carnival
   constructor: () ->
-    @setOptionsFromDefaults()
     if(CarnivalOptions.enabled)
       @elements = document.querySelectorAll(CarnivalOptions.article_selector)
       @articles = [].slice.call(@elements).map (articleElement) ->
         new Article(articleElement)
-
-  @defaults:
-    article_selector: 'article'
-    block_selector: ':scope > p, :scope > pre'
-    enabled: true
-    onNewComment: (comment) ->
-
-  setOptionsFromDefaults: ->
-    for property of Carnival.defaults
-      unless property of CarnivalOptions
-        CarnivalOptions[property] = Carnival.defaults[property]
 
   @hasClass: (elem, className) ->
     new RegExp(' ' + className + ' ').test(' ' + elem.className + ' ')

--- a/templates/init.coffee
+++ b/templates/init.coffee
@@ -1,0 +1,43 @@
+window.Carnival =
+  init: (options) ->
+    @setOptions(options)
+
+    xmlhttp = new XMLHttpRequest();
+    xmlhttp.onreadystatechange = () =>
+      if xmlhttp.readyState == 4 && xmlhttp.status == 200
+        n = document.createElement('div')
+        n.innerHTML = xmlhttp.responseText
+        document.body.appendChild(n)
+
+        @replaceScriptsRecurse(n)
+
+    xmlhttp.open('GET', '@{EmbedR siteId}?t=' + Math.random(), true);
+    xmlhttp.send();
+
+  setOptions: (options) ->
+    window.CarnivalOptions = options || {}
+
+    defaults =
+      enabled: true
+      article_author: ''
+      article_selector: 'article'
+      block_selector: ':scope > p, :scope > pre'
+      onNewComment: (comment) ->
+
+    for property of defaults
+      unless property of CarnivalOptions
+        CarnivalOptions[property] = defaults[property]
+
+  replaceScriptsRecurse: (node) ->
+    if @isScriptNode(node)
+      script = document.createElement('script')
+      script.src = node.src
+
+      node.parentNode.replaceChild(script, node)
+    else
+      @replaceScriptsRecurse(child) for child in node.childNodes
+
+    node;
+
+  isScriptNode: (node) ->
+    node.getAttribute and node.tagName == 'SCRIPT'


### PR DESCRIPTION
This brings the loading of JS/CSS from Embed into the DOM that was currently
being done directly on the Robots blog into a single initializer.

With this, default usage becomes:

```html
<script src="https://carnival.thoughtbot.com/sites/1/init.js"></script>
<script>
  Carnival.init();
</script>
```
Once deployed, I can make this change to the blog: http://sprunge.us/iVdV?diff