### PR TITLE
Only shift Article if required

### DIFF
--- a/templates/embed/Article.coffee
+++ b/templates/embed/Article.coffee
@@ -22,8 +22,10 @@ class Article
 
   bindEvents: ->
     @element.addEventListener 'commenting', (event) =>
-      Carnival.addClass(@element, 'commenting')
-      @shiftArticle()
+      unless @element.classList.contains('commenting')
+        Carnival.addClass(@element, 'commenting')
+        @shiftArticle()
+
       @thread.displayForBlock(event.detail)
     @element.addEventListener 'doneCommenting', =>
       if @element.querySelectorAll('.commenting').length is 0


### PR DESCRIPTION
When moving from paragraph to paragraph with commenting open, we were shifting
the article further and further, this guards the shifting to only occur if
needed.