### PR TITLE
Extract, improve, and test authenticateUser

### DIFF
--- a/Foundation.hs
+++ b/Foundation.hs
@@ -8,6 +8,7 @@ import Yesod.Default.Util   (addStaticContentExternal)
 import Yesod.Core.Types     (Logger)
 import qualified Yesod.Core.Unsafe as Unsafe
 
+import Model.User
 import Yesod.Auth.Dummy
 import Yesod.Auth.OAuth2.Github
 
@@ -134,14 +135,7 @@ instance YesodAuth App where
     -- Override the above two destinations when a Referer: header is present
     redirectToReferer _ = True
 
-    getAuthId creds = runDB $ do
-        muser <- getBy $ UniqueUser (credsPlugin creds) (credsIdent creds)
-
-        let newUser = buildUser creds
-
-        case muser of
-            Just (Entity uid _) -> fmap Just $ replaceUser uid newUser
-            _                   -> insertUser newUser
+    getAuthId = runDB . authenticateUser
 
     -- You can add other plugins like BrowserID, email or OAuth here
     authPlugins m = addAuthBackDoor m
@@ -155,21 +149,6 @@ instance YesodAuth App where
     loginHandler = lift $ defaultLayout $ do
         setTitle "Carnival - Login"
         $(widgetFile "login")
-
-buildUser :: Creds m -> Maybe User
-buildUser (Creds csPlugin csIdent csExtra) =
-    User <$> lookup "name" csExtra
-         <*> lookup "email" csExtra
-         <*> pure csPlugin
-         <*> pure csIdent
-
-replaceUser :: UserId -> Maybe User -> YesodDB App UserId
-replaceUser uid (Just u) = replace uid u >> return uid
-replaceUser uid _        = return uid
-
-insertUser :: Maybe User -> YesodDB App (Maybe UserId)
-insertUser (Just u) = fmap Just $ insert u
-insertUser _        = return Nothing
 
 addAuthBackDoor :: App -> [AuthPlugin App] -> [AuthPlugin App]
 addAuthBackDoor app =

--- a/Model/User.hs
+++ b/Model/User.hs
@@ -4,9 +4,10 @@ module Model.User
     , userGravatar
     , findUsers
     , findUsers'
+    , authenticateUser
     ) where
 
-import Import
+import Import.NoFoundation
 
 import Network.Gravatar
 
@@ -29,3 +30,23 @@ findUsers userIds = selectList [UserId <-. userIds] []
 -- | Same as @findUsers@, but discards the @entityKey@
 findUsers' :: [UserId] -> DB [User]
 findUsers' = fmap (map entityVal) . findUsers
+
+authenticateUser :: Creds m -> DB (Maybe UserId)
+authenticateUser creds@Creds{..} = do
+    muser <- getBy $ UniqueUser credsPlugin credsIdent
+    muserId <- mapM upsertUser $ credsToUser creds
+
+    return $ muserId <|> (entityKey <$> muser)
+
+upsertUser :: User -> DB UserId
+upsertUser user = entityKey <$> upsert user
+    [ UserName =. userName user
+    , UserEmail =. userEmail user
+    ]
+
+credsToUser :: Creds m -> Maybe User
+credsToUser Creds{..} = User
+    <$> lookup "name" credsExtra
+    <*> lookup "email" credsExtra
+    <*> pure credsPlugin
+    <*> pure credsIdent

--- a/test/Model/UserSpec.hs
+++ b/test/Model/UserSpec.hs
@@ -1,0 +1,72 @@
+module Model.UserSpec
+    ( main
+    , spec
+    ) where
+
+import TestImport
+import Model.User
+import Yesod.Auth (Creds(..))
+import qualified Database.Persist as DB
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = withApp $ do
+    describe "authenticateUser" $ do
+        it "creates a new user based on the given credentials" $ do
+            let creds = Creds
+                    { credsPlugin = "github"
+                    , credsIdent = "1"
+                    , credsExtra =
+                        [ ("name", "foo")
+                        , ("email", "bar@gmail.com")
+                        ]
+                    }
+
+            Just userId <- runDB $ authenticateUser creds
+
+            Just user <- runDB $ DB.get userId
+            userPlugin user `shouldBe` "github"
+            userIdent user `shouldBe` "1"
+            userName user `shouldBe` "foo"
+            userEmail user `shouldBe` "bar@gmail.com"
+
+        it "updates an existing user based on the given credentials" $ do
+            Entity userId user <- runDB $ createUser "1"
+            let creds = Creds
+                    { credsPlugin = userPlugin user
+                    , credsIdent = userIdent user
+                    , credsExtra =
+                        [ ("name", "new")
+                        , ("email", "new@gmail.com")
+                        ]
+                    }
+
+            Just userId' <- runDB $ authenticateUser creds
+            userId' `shouldBe` userId
+
+            Just user' <- runDB $ DB.get userId'
+            userPlugin user' `shouldBe` userPlugin user
+            userIdent user' `shouldBe` userIdent user
+            userName user' `shouldBe` "new"
+            userEmail user' `shouldBe` "new@gmail.com"
+
+        it "authenticates known users even if profile data is missing" $ do
+            Entity userId user <- runDB $ createUser "1"
+            let creds = Creds
+                    { credsPlugin = userPlugin user
+                    , credsIdent = userIdent user
+                    , credsExtra = []
+                    }
+
+            (runDB $ authenticateUser creds) `shouldReturn` Just userId
+
+        it "does not authenticate unknown users if profile data is missing" $ do
+            let creds = Creds
+                    { credsPlugin = "github"
+                    , credsIdent = "1"
+                    , credsExtra = []
+                    }
+
+            runDB (authenticateUser creds) `shouldReturn` Nothing


### PR DESCRIPTION
This code has actually been a source of bugs. With the new scaffold's
`Import.NoFoundation`, we're able to extract more code out of `Foundation`
without running into circular imports. Moving this to `Model.User` made it easy
to test.