### PR TITLE
Include Accept header in getUser request

### DIFF
--- a/templates/embed/Carnival.coffee
+++ b/templates/embed/Carnival.coffee
@@ -56,6 +56,7 @@ class Carnival
     request = new XMLHttpRequest
     request.withCredentials = true
     request.open('GET', '@{UserR}', false)
+    request.setRequestHeader('Accept', 'application/json')
     request.send()
     if request.status is 200
       @user = JSON.parse(request.responseText).user


### PR DESCRIPTION
Now that we rely on Yesod's automatic JSON responses to authentication routes,
we must supply a proper Accept header to get them.