### PR TITLE
Take advantage of AuthenticationResult

### DIFF
--- a/Foundation.hs
+++ b/Foundation.hs
@@ -136,7 +136,7 @@ instance YesodAuth App where
     -- Override the above two destinations when a Referer: header is present
     redirectToReferer _ = True
 
-    getAuthId = runDB . authenticateUser
+    authenticate = runDB . authenticateUser
 
     -- You can add other plugins like BrowserID, email or OAuth here
     authPlugins m = addAuthBackDoor m

--- a/test/Factories.hs
+++ b/test/Factories.hs
@@ -37,8 +37,8 @@ createUser ident = do
     Entity planId _ <- createFreePlan
 
     insertEntity User
-        { userName = "John Smith (" ++ ident ++ ")"
-        , userEmail = "john-" ++ ident ++ "@gmail.com"
+        { userName = "Dummy Login"
+        , userEmail = "dummy@example.com"
         , userPlugin = "dummy"
         , userIdent = ident
         , userPlan = planId

--- a/test/Model/UserSpec.hs
+++ b/test/Model/UserSpec.hs
@@ -5,7 +5,7 @@ module Model.UserSpec
 
 import TestImport
 import Model.User
-import Yesod.Auth (Creds(..))
+import Yesod.Auth (AuthenticationResult(..), Creds(..))
 import qualified Database.Persist as DB
 
 main :: IO ()
@@ -14,61 +14,104 @@ main = hspec spec
 spec :: Spec
 spec = withApp $ do
     describe "authenticateUser" $ do
-        it "creates a new user based on the given credentials" $ do
-            void $ runDB createFreePlan
+        it "creates a new user with plugin, ident, and the free plan" $ do
+            Entity planId _ <- runDB createFreePlan
 
             let creds = Creds
-                    { credsPlugin = "github"
+                    { credsPlugin = "dummy"
                     , credsIdent = "1"
-                    , credsExtra =
-                        [ ("name", "foo")
-                        , ("email", "bar@gmail.com")
-                        ]
+                    , credsExtra = []
                     }
 
-            Just userId <- runDB $ authenticateUser creds
+            Authenticated userId <- runDB $ authenticateUser' creds
 
             Just user <- runDB $ DB.get userId
-            userPlugin user `shouldBe` "github"
-            userIdent user `shouldBe` "1"
-            userName user `shouldBe` "foo"
-            userEmail user `shouldBe` "bar@gmail.com"
+            userPlugin user `shouldBe` credsPlugin creds
+            userIdent user `shouldBe` credsIdent creds
+            userPlan user `shouldBe` planId
 
-        it "updates an existing user based on the given credentials" $ do
+        it "authenticates a known user by plugin/ident" $ do
             Entity userId user <- runDB $ createUser "1"
             let creds = Creds
                     { credsPlugin = userPlugin user
                     , credsIdent = userIdent user
-                    , credsExtra =
-                        [ ("name", "new")
-                        , ("email", "new@gmail.com")
-                        ]
+                    , credsExtra = []
                     }
 
-            Just userId' <- runDB $ authenticateUser creds
+            Authenticated userId' <- runDB $ authenticateUser' creds
+
             userId' `shouldBe` userId
 
-            Just user' <- runDB $ DB.get userId'
-            userPlugin user' `shouldBe` userPlugin user
-            userIdent user' `shouldBe` userIdent user
-            userName user' `shouldBe` "new"
-            userEmail user' `shouldBe` "new@gmail.com"
+        context "from GitHub" $ do
+            it "creates a user from the profile data" $ do
+                void $ runDB createFreePlan
+                let creds = Creds
+                        { credsPlugin = "github"
+                        , credsIdent = "1"
+                        , credsExtra =
+                            [ ("name", "foo")
+                            , ("email", "bar@gmail.com")
+                            ]
+                        }
 
-        it "authenticates known users even if profile data is missing" $ do
-            Entity userId user <- runDB $ createUser "1"
-            let creds = Creds
-                    { credsPlugin = userPlugin user
-                    , credsIdent = userIdent user
-                    , credsExtra = []
-                    }
+                Authenticated userId <- runDB $ authenticateUser' creds
 
-            (runDB $ authenticateUser creds) `shouldReturn` Just userId
+                Just user <- runDB $ DB.get userId
+                userName user `shouldBe` "foo"
+                userEmail user `shouldBe` "bar@gmail.com"
 
-        it "does not authenticate unknown users if profile data is missing" $ do
-            let creds = Creds
-                    { credsPlugin = "github"
-                    , credsIdent = "1"
-                    , credsExtra = []
-                    }
+            it "updates an existing user's profile data" $ do
+                let creds = Creds
+                        { credsPlugin = "github"
+                        , credsIdent = "1"
+                        , credsExtra =
+                            [ ("name", "foo")
+                            , ("email", "bar@gmail.com")
+                            ]
+                        }
+                userId <- runDB $ do
+                    Entity planId _ <- createFreePlan
 
-            runDB (authenticateUser creds) `shouldReturn` Nothing
+                    insert User
+                        { userName = ""
+                        , userEmail = ""
+                        , userPlugin = credsPlugin creds
+                        , userIdent = credsIdent creds
+                        , userPlan = planId
+                        , userStripeId = Nothing
+                        }
+
+                Authenticated userId' <- runDB $ authenticateUser' creds
+
+                userId' `shouldBe` userId
+
+                Just user <- runDB $ DB.get userId
+                userName user `shouldBe` "foo"
+                userEmail user `shouldBe` "bar@gmail.com"
+
+            it "errors if name is missing" $ do
+                let creds = Creds
+                        { credsPlugin = "github"
+                        , credsIdent = "1"
+                        , credsExtra = [("email", "foo@gmail.com")]
+                        }
+
+                ServerError msg <- runDB $ authenticateUser' creds
+
+                msg `shouldBe` "github: missing key name"
+
+            it "errors if email is missing" $ do
+                let creds = Creds
+                        { credsPlugin = "github"
+                        , credsIdent = "1"
+                        , credsExtra = [("name", "foo")]
+                        }
+
+                ServerError msg <- runDB $ authenticateUser' creds
+
+                msg `shouldBe` "github: missing key email"
+
+-- A synonym is required to fix m as App because we use the result as a concrete
+-- AuthId App (i.e. UserId) so it can't be the generic AuthId m
+authenticateUser' :: Creds App -> DB (AuthenticationResult App)
+authenticateUser' = authenticateUser


### PR DESCRIPTION
- Modify authenticateUser to return an AuthenticationResult
- Internally, use Either to propagate error messages that will
 ultimately get logged in the case of failed authentications
- Specifically parse credsExtra based on the plugin used
- Separate plugin-specific behavior in implementation and test

Reasoning:

Using AuthenticationResult and returning useful ServerError values, should help
debugging. Splitting out the credsExtra parsing this way will making adding new
plugins (that return different credsExtra maps) easier. Supporting the dummy
plugin via dummyProfile makes it possible to write plugin-agnostic examples in
the test and only test plugin-specific behavior in the GitHub (and eventually
Google, Twitter, etc) contexts.