### PR TITLE
Improvements to authentication spec

### DIFF
--- a/Model/User.hs
+++ b/Model/User.hs
@@ -5,6 +5,10 @@ module Model.User
     , findUsers
     , findUsers'
     , authenticateUser
+
+    -- Exported for tests
+    , Profile(..)
+    , dummyProfile
     ) where
 
 import Import.NoFoundation

--- a/carnival.cabal
+++ b/carnival.cabal
@@ -166,7 +166,9 @@ test-suite test
                 ViewPatterns
                 TupleSections
 
+                FlexibleInstances
                 RankNTypes
+                StandaloneDeriving
 
     build-depends: base
                  , carnival

--- a/test/Factories.hs
+++ b/test/Factories.hs
@@ -6,6 +6,7 @@ module Factories
     ) where
 
 import Model
+import Model.User
 import Settings
 
 import ClassyPrelude
@@ -37,8 +38,8 @@ createUser ident = do
     Entity planId _ <- createFreePlan
 
     insertEntity User
-        { userName = "Dummy Login"
-        , userEmail = "dummy@example.com"
+        { userName = profileName dummyProfile
+        , userEmail = profileEmail dummyProfile
         , userPlugin = "dummy"
         , userIdent = ident
         , userPlan = planId


### PR DESCRIPTION
- Derive Show/Eq for AuthenticationResult
- Extract shouldCreateWith/shouldUpdateWith assertions

Another change pulled out of a branch where I'm adding Google authentication.

The Show/Eq instances allow assertions against AuthenticationResult values
which replace generic pattern match failures with something useful. The
extracted assertions are reused when testing Google logins. Once Profile was
exported for the assertions, it made sense to also export dummyProfile to
remove that data duplication.