### PR TITLE
Automate Halcyon steps if BUILD=1

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -4,11 +4,27 @@
 #
 #   APP defaults to carnival-staging
 #
+#   Set BUILD=1 to perform a Halcyon build
+#
 ###
 set -e
 
 case "${1:-carnival-staging}" in
-  carnival-staging) git push staging master ;;
+  carnival-staging)
+    git push --force staging master
+
+    if [ -n "$BUILD" ]; then
+      heroku run --size=PX build
+
+      git checkout -b deploy
+      git commit --allow-empty -m "Trigger deployment"
+      git push --force staging deploy:master
+      git checkout master
+      git branch -D deploy
+
+      heroku ps:scale web=1
+    fi
+    ;;
   carnival-production)
     heroku pipeline:promote --app carnival-staging
     heroku restart --app carnival-production


### PR DESCRIPTION
- Using the environment variable (vs a flag to bin/deploy) allows for handling
  builds on migrate-deploys too, where you don't invoke bin/deploy directly.