### PR TITLE
Enforce unique emails on User

### DIFF
--- a/test/Model/UserSpec.hs
+++ b/test/Model/UserSpec.hs
@@ -54,6 +54,19 @@ spec = withApp $ do
 
             runDB (authenticateUser' creds) `shouldReturn` Authenticated userId
 
+        it "ensures a unique email for new users" $ do
+            Entity _ user <- runDB $ createUser "1"
+            let creds = Creds
+                    { credsPlugin = userPlugin user
+                    -- Note: the dummy plugin always uses the same email. Just
+                    -- need to ensure we create a new user
+                    , credsIdent = "2"
+                    , credsExtra = []
+                    }
+
+            runDB (authenticateUser' creds)
+                `shouldReturn` UserError InvalidEmailAddress
+
         context "from GitHub" $ do
             let creds = Creds
                     { credsPlugin = "github"


### PR DESCRIPTION
Caveats:

- This is only at app-level, no DB constraint (yet)
- This is only on *new* users, not profile updates to existing users (yet)

Rationale:

Adding the DB constraint fails almost all of our tests. Our user factory
actually does create users with unique emails, but authenticating with the
dummy plugin always attempts to update it to the same address. Modifying that
behavior will be both messy and unrelated to this validation, so I want to do
it separately.

I thought it made sense to do this first, since it should prevent creating
users with non-unique emails in production while I'm working on adding the more
robust, DB-level constraint.

Once the constraint is in and the test behavior corrected, I'll change the
update path to also handle uniqueness violations gracefully.