### PR TITLE
Add unique constraint on UserEmail

### DIFF
--- a/config/models
+++ b/config/models
@@ -24,6 +24,7 @@ User
     plan PlanId
     stripeId S.CustomerId Maybe
     UniqueUser plugin ident
+    UniqueEmail email
     deriving Eq Show Typeable
 
 Membership

--- a/test/Factories.hs
+++ b/test/Factories.hs
@@ -8,7 +8,6 @@ module Factories
     ) where
 
 import Model
-import Model.User
 import Settings
 
 import ClassyPrelude
@@ -39,8 +38,8 @@ buildPlan = Plan
 
 buildUser :: User
 buildUser = User
-    { userName = profileName dummyProfile
-    , userEmail = profileEmail dummyProfile
+    { userName = "user"
+    , userEmail = "user@example.com"
     , userPlugin = "dummy"
     , userIdent = "1"
     , userPlan = somePlanId
@@ -62,7 +61,9 @@ createUser ident = do
     Entity planId _ <- createFreePlan
 
     insertEntity buildUser
-        { userIdent = ident
+        { userName = "user-" ++ ident
+        , userEmail = "user-" ++ ident ++ "@example.com"
+        , userIdent = ident
         , userPlan = planId
         }
 

--- a/test/Model/SiteSpec.hs
+++ b/test/Model/SiteSpec.hs
@@ -43,7 +43,9 @@ attachPlansToSite plans = do
     planIds <- forM plans insert
     userIds <- forM planIds $ \planId -> insert buildUser
         { userPlan = planId
-        , userIdent = pack $ show planId -- to make it unique
+        -- to make unique values
+        , userIdent = pack $ show planId
+        , userEmail = (pack $ show planId) ++ "@example.com"
         }
 
     void $ forM userIds $ \userId -> insert $ Membership siteId userId

--- a/test/Model/UserSpec.hs
+++ b/test/Model/UserSpec.hs
@@ -30,7 +30,7 @@ spec = withApp $ do
             let creds = Creds
                     { credsPlugin = "dummy"
                     , credsIdent = "1"
-                    , credsExtra = []
+                    , credsExtra = [("name", ""), ("email", "")]
                     }
 
             result <- runDB $ authenticateUser' creds


### PR DESCRIPTION
- Re-use githubProfile for dummy logins because tests now need more
 realistic behavior regarding user emails
- Replace upsertUser with separate replace/insert functions because
 upsert requires a single unique constraint on the entity