### PR TITLE
Update halcyon-build script to clear cache

### DIFF
--- a/bin/halcyon-build
+++ b/bin/halcyon-build
@@ -27,11 +27,6 @@ EOF
   exit 1
 fi
 
-if [ -d /var/tmp/halcyon-cache ]; then
-  echo 'Clearing the halcyon cache...'
-  rm -rf /var/tmp/halcyon-cache
-fi
-
 if [ ! -w /app ]; then
   sudo mkdir -p /app
   sudo chown $USER /app
@@ -45,6 +40,6 @@ fi
 export HALCYON_INTERNAL_TOLERATE_GHC_USER_DB=1
 
 /app/halcyon/halcyon build \
-  --no-clean-private-storage --cabal-version=1.22.0.0 "$@"
+  --no-clean-private-storage --cabal-version=1.22.0.0 "$@" --purge-cache
 
 ln -sf /app/sandbox/cabal.sandbox.config cabal.sandbox.config

--- a/bin/halcyon-build
+++ b/bin/halcyon-build
@@ -27,6 +27,11 @@ EOF
   exit 1
 fi
 
+if [ -d /var/tmp/halcyon-cache ]; then
+  echo 'Clearing the halcyon cache...'
+  rm -rf /var/tmp/halcyon-cache
+fi
+
 if [ ! -w /app ]; then
   sudo mkdir -p /app
   sudo chown $USER /app


### PR DESCRIPTION
* This commit updates `bin/halcyon-build` to clear the halcyon cache
  before proceeding with the build. This change is necessary to ensure
  that archives and constraints cached over the course of previous
  failed builds are not applied when the script is run.
* References:
  - halcyon cache: https://halcyon.sh/reference/#halcyon_cache
  - an issue with some discussion around clearing the halcyon cache:
  https://github.com/mietek/halcyon/issues/22