### PR TITLE
Silence unused import warnings

### DIFF
--- a/Handler/Embed.hs
+++ b/Handler/Embed.hs
@@ -5,7 +5,6 @@ import Model.Site
 import Helper.Request
 
 import Text.Julius (rawJS)
-import Yesod.Auth.OAuth2 (oauth2Url)
 
 getEmbedR :: SiteId -> Handler Html
 getEmbedR siteId = do

--- a/Handler/Root.hs
+++ b/Handler/Root.hs
@@ -2,8 +2,6 @@ module Handler.Root where
 
 import Import
 
-import Yesod.Auth.OAuth2 (oauth2Url)
-
 getRootR :: Handler Html
 getRootR = do
     muser <- maybeAuth


### PR DESCRIPTION
Now that we no longer link directly to GitHub, oauth2Url is unused.