### PR TITLE
Allow comments of any (non-zero) length

### DIFF
--- a/templates/embed.lucius
+++ b/templates/embed.lucius
@@ -192,6 +192,12 @@
   }
 }
 
+.carnival-validation-error {
+  color: #FF0000;
+  font-size: 12px;
+  padding-top: 10px;
+}
+
 @media only screen
 and (max-width: 640px) {
   .carnival {

--- a/templates/embed/CommentForm.coffee
+++ b/templates/embed/CommentForm.coffee
@@ -40,7 +40,7 @@ class CommentForm
       @showCommentForm()
 
   hasBody: ->
-    @body().replace(/\s/g, '').length > 4
+    @body().replace(/\s/g, '').length > 0
 
   showCommentForm: ->
     @element.querySelector('a').style.display = 'none'

--- a/templates/embed/CommentForm.coffee
+++ b/templates/embed/CommentForm.coffee
@@ -7,7 +7,16 @@ class CommentForm
     @element = document.createElement('li')
     @element.id = 'comment-form'
     @element.className = 'carnival-comment-form'
-    @element.innerHTML = "<a class='carnival-create'><span>+</span> Leave a comment</a><form><a class='carnival-cancel'>✖</a><div class='carnival-author'><img src=''><span></span></div><textarea placeholder='Type here&hellip;' class='carnival-body'></textarea><input type='submit' value='Comment'></form>"
+    @element.innerHTML = """
+      <a class='carnival-create'><span>+</span> Leave a comment</a>
+      <form>
+        <a class='carnival-cancel'>✖</a>
+        <div class='carnival-author'><img src=''><span></span></div>
+        <div class='carnival-validation-error'></div>
+        <textarea placeholder='Type here&hellip;' class='carnival-body'></textarea>
+        <input type='submit' value='Comment'>
+      </form>
+    """
 
   body: ->
     @element.querySelector('.carnival-body').value
@@ -54,6 +63,11 @@ class CommentForm
     @element.querySelector('a').style.display = 'block'
 
   saveComment: ->
+    error = @element.querySelector('.carnival-validation-error')
+    error.innerHTML = ''
+
     if @hasBody()
       @thread.add(@body())
       @element.querySelector('.carnival-body').value = ''
+    else
+      error.innerHTML = 'comments cannot be empty'


### PR DESCRIPTION
- Add an error message to the UI on empty comments

I'm not sure the messaging is needed once we allow comments of any non-zero
length. It's pretty obvious when submitting an *empty* comment does nothing, I
was originally confused while trying to add *non-empty* comments and it wasn't
doing anything because it was less than 4 characters (think: "+1").

That said, I added the messaging before realizing this and it's here now, so
wanted to get others' opinions before discarding it. Also, if there is a good
reason to keep the 4-character validation, I'll want the messaging again.