### PR TITLE
Revert fix for Firefox

### DIFF
--- a/templates/embed/Carnival.coffee
+++ b/templates/embed/Carnival.coffee
@@ -21,8 +21,7 @@ class Carnival
 
   @get: (url, callback) ->
     request = new XMLHttpRequest
-    request.beforeSend = (xhr) ->
-      xhr.withCredentials = true
+    request.withCredentials = true
     request.open('GET', url, true)
     request.setRequestHeader('Content-Type', 'application/json')
     request.onload = () ->
@@ -32,8 +31,7 @@ class Carnival
 
   @post: (url, data, callback) ->
     request = new XMLHttpRequest()
-    request.beforeSend = (xhr) ->
-      xhr.withCredentials = true
+    request.withCredentials = true
     request.open('POST', url, true)
     request.setRequestHeader('Content-Type', 'application/json')
     request.onload = () ->
@@ -56,8 +54,7 @@ class Carnival
 
   @getUser: ->
     request = new XMLHttpRequest
-    request.beforeSend = (xhr) ->
-      xhr.withCredentials = true
+    request.withCredentials = true
     request.open('GET', '@{UserR}', false)
     request.setRequestHeader('Accept', 'application/json')
     request.send()


### PR DESCRIPTION
- Reverts commit 83202193f3d898c874cc1f6c14bef254755730bc.
- Reverts commit af142f2e0d4227f4cdf32ccfd36d39983cdf179e.

The fix for Firefox breaks Chrome, and didn't really fix Firefox anyway.

The reason Firefox was broken is because we make a synchronous request for
user details. We should not be doing this anyway. The decision was made to
revert the Firefox "fix" and focus on making the user request async instead.