### PR TITLE
Call withEnv in TestImport.withApp

### DIFF
--- a/Application.hs
+++ b/Application.hs
@@ -4,6 +4,7 @@ module Application
     , appMain
     , develMain
     , makeFoundation
+    , withEnv
     -- * for DevelMain
     , getApplicationRepl
     , shutdownApp
@@ -178,7 +179,7 @@ appMain = do
     -- Run the application with Warp
     runSettings (warpSettings foundation) app
 
-withEnv :: IO AppSettings -> IO AppSettings
+withEnv :: IO a -> IO a
 withEnv = (loadEnv >>)
 
 --------------------------------------------------------------

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -6,7 +6,7 @@ module TestImport
     , module X
     ) where
 
-import Application           (makeFoundation)
+import Application           (makeFoundation, withEnv)
 import ClassyPrelude         as X
 import Database.Persist      as X hiding (get)
 import Database.Persist.Sql  (SqlPersistM, SqlBackend, runSqlPersistMPool, rawExecute, rawSql, unSingle, connEscapeName)
@@ -43,7 +43,7 @@ withApp = before $ do
         ["config/test-settings.yml", "config/settings.yml"]
         []
         ignoreEnv
-    foundation <- makeFoundation settings
+    foundation <- withEnv $ makeFoundation settings
     wipeDB foundation
     return foundation
 


### PR DESCRIPTION
In e7cc415f, loadEnv was moved out of makeFoundation and placed earlier in the
application boot process. This unintentionally meant it was no longer invoked
during tests was part of withApp. This was OK on CirclCI where the environment
variables are explicitly set, but breaks tests locally where they are set in
.env.