### PR TITLE
Use CSS transition for smoother commenting

### DIFF
--- a/templates/embed.lucius
+++ b/templates/embed.lucius
@@ -1,3 +1,12 @@
+@keyframes carnival-open {
+  0% { left: 0; }
+}
+
+@keyframes carnival-close {
+  0% { left: -150px; }
+  100% { left: 0; }
+}
+
 .carnival {
   display: none;
   position: absolute;
@@ -174,7 +183,12 @@
   padding-top: 5px;
 }
 
+.carnival-is-commenting {
+  animation: carnival-open 0.2s ease-in-out none;
+}
+
 .commenting {
+
   .carnival {
     display: block;
   }
@@ -190,6 +204,10 @@
   .carnival-comments {
     display: block;
   }
+}
+
+.comments-hidden {
+  animation: carnival-close 0.2s ease-in-out none;
 }
 
 .carnival-validation-error {

--- a/templates/embed/Article.coffee
+++ b/templates/embed/Article.coffee
@@ -24,12 +24,14 @@ class Article
     @element.addEventListener 'commenting', (event) =>
       unless @element.classList.contains('commenting')
         Carnival.addClass(@element, 'commenting')
+        Carnival.addClass(@element, 'carnival-is-commenting')
         @shiftArticle()
 
       @thread.displayForBlock(event.detail)
     @element.addEventListener 'doneCommenting', =>
       if @element.querySelectorAll('.commenting').length is 0
         Carnival.removeClass(@element, 'commenting')
+        Carnival.removeClass(@element, 'carnival-is-commenting')
         @restoreArticle()
 
   fetchComments: ->


### PR DESCRIPTION
When going to comment the way an article's content is moved to the left is a bit jarring and almost feels unintentional. This PR adds a CSS transition to smooth things out providing a bitter experience.

My original thought was to remove the move all together, however this has larger implications as we would have to deal with different screen sizes. I think this provides a good middle ground with a smoother transition. The gif below doesn't really do it a lot of justice as the transition seems a big jagged there.

![carnival-transition](https://cloud.githubusercontent.com/assets/105694/8012011/041c8bda-0b8c-11e5-88ac-3ad6aedfce32.gif)
