### PR TITLE
Allow GitHub authentication without a name defined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ cabal.sandbox.config
 .env
 !migrations/*.sql
 .sass-cache/
+.stack-work
+tmp

--- a/Data/Text/Instances.hs
+++ b/Data/Text/Instances.hs
@@ -1,0 +1,11 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Data.Text.Instances where
+
+import Control.Monad.Error (Error(..))
+import Data.Text (Text)
+
+import qualified Data.Text as T
+
+-- Required to use @(<|>)@ with @Either Text a@ values
+instance Error Text where
+    strMsg = T.pack

--- a/Model/User.hs
+++ b/Model/User.hs
@@ -15,6 +15,7 @@ import Import.NoFoundation
 
 import Data.Aeson
 import Data.Digest.Pure.SHA (hmacSha256)
+import Data.Text.Instances ()
 import Network.Gravatar
 import Yesod.Auth.GoogleEmail2
 
@@ -104,7 +105,7 @@ extraToProfile plugin _ = Left $ "Invalid plugin: " ++ plugin
 
 githubProfile :: [(Text, Text)] -> Either Text Profile
 githubProfile extra = Profile
-    <$> lookupExtra "name" extra
+    <$> (lookupExtra "name" extra <|> lookupExtra "login" extra)
     <*> lookupExtra "email" extra
 
 googleProfile :: [(Text, Text)] -> Either Text Profile

--- a/carnival.cabal
+++ b/carnival.cabal
@@ -51,6 +51,7 @@ library
                      Network.Mail.SendGrid
                      Network.Mail.RecipientOverride
                      Tasks
+                     Data.Text.Instances
 
     if flag(dev) || flag(library-only)
         cpp-options:   -DDEVELOPMENT

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,27 @@
+resolver: lts-2.9
+
+packages:
+- '.'
+
+extra-deps:
+- esqueleto-2.1.2.2
+- fast-logger-2.3.1
+- heroku-0.1.2.2
+- heroku-persistent-0.1.0
+- hspec-expectations-lifted-0.5.0
+- http-common-0.8.2.0
+- http-streams-0.8.3.3
+- io-streams-1.3.2.0
+- load-env-0.1.1
+- openssl-streams-1.2.1.0
+- persistent-2.1.2
+- persistent-postgresql-2.1.3
+- persistent-template-2.1.1
+- shakespeare-text-1.1.0
+- smtp-mail-0.1.4.5
+- stripe-core-2.0.2
+- stripe-haskell-0.1.3.0
+- stripe-http-streams-2.0.2
+- wai-app-static-3.0.0.6
+- warp-3.0.10.1
+- yesod-static-1.4.0.4

--- a/test/Model/UserSpec.hs
+++ b/test/Model/UserSpec.hs
@@ -84,6 +84,7 @@ spec = withApp $ do
                     , credsIdent = "1"
                     , credsExtra =
                         [ ("name", "foo")
+                        , ("login", "bar")
                         , ("email", "bar@gmail.com")
                         ]
                     }
@@ -91,14 +92,24 @@ spec = withApp $ do
             it "creates a user from the name/email values" $
                 creds `shouldCreateWith` Profile "foo" "bar@gmail.com"
 
+            it "creates from login if name is missing" $ do
+                let creds' = creds { credsExtra = [("login", "bar"), ("email", "")] }
+
+                creds' `shouldCreateWith` Profile "bar" ""
+
             it "updates an existing user from the name/email values" $
                 creds `shouldUpdateWith` Profile "foo" "bar@gmail.com"
 
-            it "errors if name is missing" $ do
+            it "updates from login if name is missing" $ do
+                let creds' = creds { credsExtra = [("login", "bar"), ("email", "")] }
+
+                creds' `shouldUpdateWith` Profile "bar" ""
+
+            it "errors if name and login is missing" $ do
                 let creds' = creds { credsExtra = [("email", "")] }
 
                 runDB (authenticateUser' creds')
-                    `shouldReturn` ServerError "github: missing key name"
+                    `shouldReturn` ServerError "github: missing key login"
 
             it "errors if email is missing" $ do
                 let creds' = creds { credsExtra = [("name", "")] }


### PR DESCRIPTION
Use Alternative to grab the profile name from the login key if/when the name
key is missing. (This required an orphan Error instance on Text.) Profiles
missing a name are possible, while login should always be present[1].

Fixes #282

1: https://github.com/thoughtbot/yesod-auth-oauth2/blob/master/Yesod/Auth/OAuth2/Github.hs#L97

I included a commit that adds stack support. Note that this is not fully-baked;
specifically, I can't get `stack test` or `yesod test` to work yet, but it does
work well enough for me to test-compile the project and run individual spec
files. If you'd prefer I keep that commit out, let me know.

/cc @jferris