### PR TITLE
Fix yesod devel command

### DIFF
--- a/carnival.cabal
+++ b/carnival.cabal
@@ -151,6 +151,9 @@ executable         carnival
     ghc-options:       -threaded -O2 -rtsopts -with-rtsopts=-N
 
 executable         carnival-task
+    if flag(library-only)
+        Buildable: False
+
     main-is:           TaskMain.hs
     hs-source-dirs:    app
     build-depends:     base, carnival


### PR DESCRIPTION
This command broke when we added the `carnival-task` executable. Running
`yesod-devel` before this commit prints this error:

    Starting development server...
    <command line>: cannot satisfy -package-id main-inplace
        (use -v for more information)
    Exit code: ExitFailure 1

Excluding the executable in library-only mode (used by `yesod devel`)
fixes the error. After this commmit, you'll need to reconfigure and
rebuild if you want to run `carnival-task` in development. Running
`yesod-devel` again will automatically reconfigure in library-only mode.

Resolves #279.