### PR TITLE
Ignore .env in when building slug

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.env
 .git
 .stack-work
 Dockerfile


### PR DESCRIPTION
If you have development settings in .env, they'll override the Heroku
configuration.

This avoids sending .env during the Docker build.